### PR TITLE
sets CDK 2.13-SNAPSHOT version for all CDK dependencies and updates t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <sonar.organization>cdk</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <cdk.version>2.12</cdk.version>
+        <cdk.version>2.13-SNAPSHOT</cdk.version>
         <junit.version>5.9.3</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
     </properties>
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>cdk-data</artifactId>
-            <version>2.13-SNAPSHOT</version>
+            <version>${cdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/openscience/cdk/tools/scaffold/ScaffoldGeneratorTest.java
+++ b/src/test/java/org/openscience/cdk/tools/scaffold/ScaffoldGeneratorTest.java
@@ -945,7 +945,7 @@ public class ScaffoldGeneratorTest extends ScaffoldGenerator {
                 "C1CCCC(/C(=C(/C2CCCNCCC2)\\C3CCCCC(C4CCCC(CC(CC5CCNCC5)=C)C4)CC3)/C6CCCCCNC6)CCC1",
                 "C1CCCC(/C(=C(/C2CCCNCCC2)\\C3CCCCC(C4CCCCC4)CC3)/C5CCCCCNC5)CCC1",
                 "C1CCCC(/C(=C(/C2CCCNCCC2)\\C3CCCCCCC3)/C4CCCCCNC4)CCC1",
-                "C(=C(/C1CCCNCCC1)\\C2CCCCCCC2)/C3CCCCCNC3",
+                "C(=C(\\C1CCCNCCC1)/C2CCCCCCC2)\\C3CCCCCNC3",
                 "C(C1CCCNCCC1)(C2CCCCCCC2)=C",
                 "C1CCCNCCC1"
         };


### PR DESCRIPTION
…he formerly failing structure to the completely inverted (but correct!) form that is now generated.

@egonw it wasn't enough to only update the version of cdk-data, apparently. It worked correctly after I set 2.13-SNAPSHOT for all CDK dependencies.