### PR TITLE
Update badges and enhance citation information in README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,14 @@ authors:
   - family-names: "Steinbeck"
     given-names: "Christoph"
     orcid: "https://orcid.org/0000-0001-6966-0814"
+  - family-names: "Willighagen"
+    given-names: "Egon"
+    orcid: "https://orcid.org/0000-0001-7542-0286"
+  - family-names: "Mayfield"
+    given-names: "John"
+    orcid: "https://orcid.org/0000-0001-7730-2646"
 doi: "10.5281/zenodo.7940339"
-date-released: 2026-07-26
+date-released: 2026-08-04
 url: "https://github.com/cdk/cdk-scaffold"
 license: LGPL-2.1
 references:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=cdk_cdk-scaffold&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=cdk_cdk-scaffold)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=cdk_cdk-scaffold&metric=bugs)](https://sonarcloud.io/summary/new_code?id=cdk_cdk-scaffold) 
 --->
-[![DOI](https://zenodo.org/badge/638930745.svg)](https://zenodo.org/badge/latestdoi/638930745)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21788196.svg)](https://doi.org/10.5281/zenodo.21788196)
 [![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](http://cdk.github.io/cdk-scaffold/latest/docs/api/index.html?overview-summary.html)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.openscience.cdk/cdk-scaffold/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.openscience.cdk/cdk-scaffold) 
+[![Maven Central Version](https://img.shields.io/maven-central/v/org.openscience.cdk/cdk-scaffold)](https://central.sonatype.com/artifact/org.openscience.cdk/cdk-scaffold)
 [![build](https://github.com/cdk/cdk-scaffold/actions/workflows/maven.yml/badge.svg)](https://github.com/cdk/cdk-scaffold/actions/workflows/maven.yml) 
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-blue.svg)](https://GitHub.com/cdk/cdk-scaffold/graphs/commit-activity)
 [![GitHub issues](https://img.shields.io/github/issues/cdk/cdk-scaffold.svg)](https://GitHub.com/cdk/cdk-scaffold/issues/)
 [![GitHub contributors](https://img.shields.io/github/contributors/cdk/cdk-scaffold.svg)](https://GitHub.com/cdk/cdk-scaffold/graphs/contributors/)
 [![GitHub release](https://img.shields.io/github/release/cdk/cdk-scaffold.svg)](https://github.com/cdk/cdk-scaffold/releases/)
+<!---
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=cdk_cdk-scaffold&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=cdk_cdk-scaffold)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=cdk_cdk-scaffold&metric=bugs)](https://sonarcloud.io/summary/new_code?id=cdk_cdk-scaffold) 
+--->
 [![DOI](https://zenodo.org/badge/638930745.svg)](https://zenodo.org/badge/latestdoi/638930745)
 [![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](http://cdk.github.io/cdk-scaffold/latest/docs/api/index.html?overview-summary.html)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Copyright &copy; 2023-2026 The CDK Development Team, especially
 [Julian Zander](https://github.com/Julian-W98),
 [Jonas Schaub](https://github.com/JonasSchaub),
 [Achim Zielesny](https://github.com/zielesny),
-[Christoph Steinbeck](https://github.com/steinbeck)
-[Egon Willighagen](https://github.com/egonw)
+[Christoph Steinbeck](https://github.com/steinbeck),
+[Egon Willighagen](https://github.com/egonw),
 [John Mayfield](https://github.com/johnmay)
 
 License: LGPL v2.1, see [LICENSE.txt](https://github.com/cdk/cdk-scaffold/blob/main/LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@
 ## Scaffold Functionalities for the Chemistry Development Kit (CDK)
  
 Copyright &copy; 2023-2026 The CDK Development Team, especially
-[Julian Zander](mailto:zanderjulian@gmx.de),
-[Jonas Schaub](mailto:jonas.schaub@uni-jena.de),
-[Achim Zielesny](mailto:achim.zielesny@w-hs.de),
-[Christoph Steinbeck](mailto:christoph.steinbeck@uni-jena.de)
+[Julian Zander](https://github.com/Julian-W98),
+[Jonas Schaub](https://github.com/JonasSchaub),
+[Achim Zielesny](https://github.com/zielesny),
+[Christoph Steinbeck](https://github.com/steinbeck)
+[Egon Willighagen](https://github.com/egonw)
+[John Mayfield](https://github.com/johnmay)
 
 License: LGPL v2.1, see [LICENSE.txt](https://github.com/cdk/cdk-scaffold/blob/main/LICENSE.txt).
 
@@ -59,7 +61,7 @@ If you are using Maven, you can install the cdk-scaffold package using:
 
 ### Snapshot releases
 
-For snapshot releases (currently `2.9-SNAPSHOT`) include the following fragment to define the
+For snapshot releases (currently `2.10-SNAPSHOT`) include the following fragment to define the
 snapshot repository:
  
 ```xml

--- a/pom.xml
+++ b/pom.xml
@@ -52,18 +52,39 @@
     </issueManagement>
 
     <developers>
-      <developer>
-        <name>Jonas Schaub</name>
-        <email>jonas.schaub@uni-jena.de</email>
-        <organization>Friedrich Schiller University Jena</organization>
-        <organizationUrl>https://cheminf.uni-jena.de</organizationUrl>
-      </developer>
-      <developer>
-        <name>Egon Willighagen</name>
-        <email>egon.willighagen@maastrichtuniversity.nl</email>
-        <organization>Maastricht University</organization>
-        <organizationUrl>http://www.bigcat.unimaas.nl/</organizationUrl>
-      </developer>
+        <developer>
+            <name>Jonas Schaub</name>
+            <email>jonas.schaub@uni-jena.de</email>
+            <organization>Friedrich Schiller University Jena</organization>
+            <organizationUrl>https://cheminf.uni-jena.de</organizationUrl>
+        </developer>
+        <developer>
+            <name>Egon Willighagen</name>
+            <email>egon.willighagen@maastrichtuniversity.nl</email>
+            <organization>Maastricht University</organization>
+            <organizationUrl>http://www.bigcat.unimaas.nl/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Mayfield</name>
+            <email>john@nextmovesoftware.com</email>
+            <url>http://www.github.com/johnmay/</url>
+        </developer>
+        <developer>
+            <name>Julian Zander</name>
+            <url>https://github.com/Julian-W98</url>
+        </developer>
+        <developer>
+            <name>Christoph Steinbeck</name>
+            <email>christoph.steinbeck@uni-jena.de</email>
+            <organization>Friedrich Schiller University Jena</organization>
+            <organizationUrl>https://cheminf.uni-jena.de</organizationUrl>
+        </developer>
+        <developer>
+            <name>Achim Zielesny</name>
+            <email>achim.zielesny@w-hs.de</email>
+            <organization>Westphalian University of Applied Sciences</organization>
+            <organizationUrl>https://www.en.w-hs.de</organizationUrl>
+        </developer>
     </developers>
 
     <!-- define the cdk.repo.url and cdk.repo.snapshots.url properties in 


### PR DESCRIPTION
This pull request updates project metadata and documentation to improve author attribution, update versioning, and enhance the information provided to users and contributors.

**Documentation and Metadata Updates:**

* Updated the Maven Central badge and DOI badge in `README.md` for improved accuracy and appearance.
* Added GitHub profile links for all listed authors in `README.md`, and included Egon Willighagen and John Mayfield as new contributors.
* Updated the snapshot release version from `2.9-SNAPSHOT` to `2.10-SNAPSHOT` in the Maven instructions.

**Author and Contributor Attribution:**

* Added Egon Willighagen and John Mayfield as authors in `CITATION.cff`, and updated the release date.
* Added detailed entries for John Mayfield, Julian Zander, Christoph Steinbeck, and Achim Zielesny in the `pom.xml` developers section.